### PR TITLE
chore: enforce .editorconfig conformance with 2-space indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 *.tmp
 *.temp
 .cache/
+__pycache__/

--- a/Scripts/deduplicate.py
+++ b/Scripts/deduplicate.py
@@ -13,84 +13,84 @@ from pathlib import Path
 
 
 def deduplicate_file(filepath):
-    """Deduplicate entries in a single file"""
-    print(f"Processing: {filepath}")
+  """Deduplicate entries in a single file"""
+  print(f"Processing: {filepath}")
 
-    try:
-        with open(filepath, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
-    except Exception as e:
-        print(f"  Error reading file: {e}")
-        return False
+  try:
+    with open(filepath, 'r', encoding='utf-8') as f:
+      lines = f.readlines()
+  except Exception as e:
+    print(f"  Error reading file: {e}")
+    return False
 
-    original_count = len(lines)
+  original_count = len(lines)
 
-    # Remove duplicates while preserving order, then sort
-    seen = set()
-    unique_lines = []
+  # Remove duplicates while preserving order, then sort
+  seen = set()
+  unique_lines = []
 
-    for line in lines:
-        # Strip trailing whitespace but keep the content
-        stripped = line.rstrip()
+  for line in lines:
+    # Strip trailing whitespace but keep the content
+    stripped = line.rstrip()
 
-        # Skip empty lines
-        if not stripped:
-            continue
+    # Skip empty lines
+    if not stripped:
+      continue
 
-        # Check if we've seen this line before (case-sensitive)
-        if stripped not in seen:
-            seen.add(stripped)
-            unique_lines.append(stripped)
+    # Check if we've seen this line before (case-sensitive)
+    if stripped not in seen:
+      seen.add(stripped)
+      unique_lines.append(stripped)
 
-    # Sort the unique lines
-    unique_lines.sort()
+  # Sort the unique lines
+  unique_lines.sort()
 
-    deduplicated_count = len(unique_lines)
-    removed_count = original_count - deduplicated_count
+  deduplicated_count = len(unique_lines)
+  removed_count = original_count - deduplicated_count
 
-    # Write back to file with LF line endings
-    try:
-        with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
-            for line in unique_lines:
-                f.write(line + '\n')
-    except Exception as e:
-        print(f"  Error writing file: {e}")
-        return False
+  # Write back to file with LF line endings
+  try:
+    with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
+      for line in unique_lines:
+        f.write(line + '\n')
+  except Exception as e:
+    print(f"  Error writing file: {e}")
+    return False
 
-    print(f"  Original: {original_count} lines")
-    print(f"  After deduplication: {deduplicated_count} lines")
-    print(f"  Removed: {removed_count} duplicates/empty lines")
+  print(f"  Original: {original_count} lines")
+  print(f"  After deduplication: {deduplicated_count} lines")
+  print(f"  Removed: {removed_count} duplicates/empty lines")
 
-    return True
+  return True
 
 
 def main():
-    # Get the lists directory
-    script_dir = Path(__file__).parent
-    repo_dir = script_dir.parent
-    lists_dir = repo_dir / 'lists'
+  # Get the lists directory
+  script_dir = Path(__file__).parent
+  repo_dir = script_dir.parent
+  lists_dir = repo_dir / 'lists'
 
-    if not lists_dir.exists():
-        print(f"Error: Lists directory not found at {lists_dir}")
-        sys.exit(1)
+  if not lists_dir.exists():
+    print(f"Error: Lists directory not found at {lists_dir}")
+    sys.exit(1)
 
-    # Find all .txt files in the lists directory
-    txt_files = sorted(lists_dir.glob('*.txt'))
+  # Find all .txt files in the lists directory
+  txt_files = sorted(lists_dir.glob('*.txt'))
 
-    if not txt_files:
-        print("No .txt files found in lists directory")
-        sys.exit(1)
+  if not txt_files:
+    print("No .txt files found in lists directory")
+    sys.exit(1)
 
-    print(f"Found {len(txt_files)} files to process\n")
+  print(f"Found {len(txt_files)} files to process\n")
 
-    success_count = 0
-    for filepath in txt_files:
-        if deduplicate_file(filepath):
-            success_count += 1
-        print()
+  success_count = 0
+  for filepath in txt_files:
+    if deduplicate_file(filepath):
+      success_count += 1
+    print()
 
-    print(f"Successfully processed {success_count}/{len(txt_files)} files")
+  print(f"Successfully processed {success_count}/{len(txt_files)} files")
 
 
 if __name__ == '__main__':
-    main()
+  main()

--- a/Scripts/deduplicate_across_files.py
+++ b/Scripts/deduplicate_across_files.py
@@ -10,70 +10,70 @@ from collections import defaultdict
 
 
 def find_cross_file_duplicates(lists_dir):
-    """Find entries that appear in multiple files"""
+  """Find entries that appear in multiple files"""
 
-    # Dictionary to track which files contain each entry
-    entry_locations = defaultdict(list)
+  # Dictionary to track which files contain each entry
+  entry_locations = defaultdict(list)
 
-    # Read all files
-    txt_files = sorted(lists_dir.glob('*.txt'))
+  # Read all files
+  txt_files = sorted(lists_dir.glob('*.txt'))
 
-    print(f"Scanning {len(txt_files)} files for cross-file duplicates...\n")
+  print(f"Scanning {len(txt_files)} files for cross-file duplicates...\n")
 
-    for filepath in txt_files:
-        filename = filepath.name
-        try:
-            with open(filepath, 'r', encoding='utf-8') as f:
-                for line in f:
-                    stripped = line.strip()
-                    if stripped:
-                        entry_locations[stripped].append(filename)
-        except Exception as e:
-            print(f"Error reading {filename}: {e}")
+  for filepath in txt_files:
+    filename = filepath.name
+    try:
+      with open(filepath, 'r', encoding='utf-8') as f:
+        for line in f:
+          stripped = line.strip()
+          if stripped:
+            entry_locations[stripped].append(filename)
+    except Exception as e:
+      print(f"Error reading {filename}: {e}")
 
-    # Find duplicates
-    duplicates = {entry: files for entry, files in entry_locations.items() if len(files) > 1}
+  # Find duplicates
+  duplicates = {entry: files for entry, files in entry_locations.items() if len(files) > 1}
 
-    if duplicates:
-        print(f"Found {len(duplicates)} entries that appear in multiple files:\n")
+  if duplicates:
+    print(f"Found {len(duplicates)} entries that appear in multiple files:\n")
 
-        # Group by file combinations for better readability
-        file_groups = defaultdict(list)
-        for entry, files in duplicates.items():
-            file_key = tuple(sorted(files))
-            file_groups[file_key].append(entry)
+    # Group by file combinations for better readability
+    file_groups = defaultdict(list)
+    for entry, files in duplicates.items():
+      file_key = tuple(sorted(files))
+      file_groups[file_key].append(entry)
 
-        for files, entries in sorted(file_groups.items()):
-            print(f"\n{len(entries)} entries appear in: {', '.join(files)}")
-            for entry in sorted(entries)[:10]:  # Show first 10
-                print(f"  - {entry}")
-            if len(entries) > 10:
-                print(f"  ... and {len(entries) - 10} more")
+    for files, entries in sorted(file_groups.items()):
+      print(f"\n{len(entries)} entries appear in: {', '.join(files)}")
+      for entry in sorted(entries)[:10]:  # Show first 10
+        print(f"  - {entry}")
+      if len(entries) > 10:
+        print(f"  ... and {len(entries) - 10} more")
 
-        return True
-    else:
-        print("✓ No cross-file duplicates found!")
-        return False
+    return True
+  else:
+    print("✓ No cross-file duplicates found!")
+    return False
 
 
 def main():
-    script_dir = Path(__file__).parent
-    repo_dir = script_dir.parent
-    lists_dir = repo_dir / 'lists'
+  script_dir = Path(__file__).parent
+  repo_dir = script_dir.parent
+  lists_dir = repo_dir / 'lists'
 
-    if not lists_dir.exists():
-        print(f"Error: Lists directory not found at {lists_dir}")
-        sys.exit(1)
+  if not lists_dir.exists():
+    print(f"Error: Lists directory not found at {lists_dir}")
+    sys.exit(1)
 
-    has_duplicates = find_cross_file_duplicates(lists_dir)
+  has_duplicates = find_cross_file_duplicates(lists_dir)
 
-    if has_duplicates:
-        print("\n" + "="*60)
-        print("Note: Cross-file duplicates are not automatically removed.")
-        print("Review the duplicates above to determine if they should be")
-        print("consolidated into a single file or kept separate by design.")
-        print("="*60)
+  if has_duplicates:
+    print("\n" + "="*60)
+    print("Note: Cross-file duplicates are not automatically removed.")
+    print("Review the duplicates above to determine if they should be")
+    print("consolidated into a single file or kept separate by design.")
+    print("="*60)
 
 
 if __name__ == '__main__':
-    main()
+  main()


### PR DESCRIPTION
Convert Python scripts from 4-space to 2-space indentation to match project-wide .editorconfig standard. All files now conform to:
- 2-space indentation
- LF line endings
- UTF-8 encoding
- No trailing whitespace
- Final newline inserted

Changes:
- Scripts/deduplicate.py: 4-space → 2-space indent
- Scripts/deduplicate_across_files.py: 4-space → 2-space indent
- .gitignore: add __pycache__/ exclusion

Verified: All files pass editorconfig compliance checks
Exit status: 0 (zero errors)